### PR TITLE
Fixed call to __delay_us()

### DIFF
--- a/lib/servo.c
+++ b/lib/servo.c
@@ -4,12 +4,13 @@
 ** (https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library)
 **
 */
+// #define FCY 800000
 
 #include <p24FJ128GB206.h>
-// #include <libpic30.h>
+#include "common.h"
+#include <libpic30.h>
 #include <math.h>
 #include <stdbool.h>
-#include "common.h"
 #include "pin.h"
 #include "i2c.h"
 #include "servo.h"
@@ -73,7 +74,7 @@ void servo_driver_wake(_SERVODRIVER *self) {
     servo_driver_begin_transmission(self, I2C_WRITE);
     servo_driver_write_register(self, PCA9685_MODE1, self -> mode1);
     servo_driver_end_transmission(self);
-    // __delay_us(500); // Oscillator takes max 500us to restart from sleep
+    __delay_us(500); // Oscillator takes max 500us to restart from sleep
     servo_driver_begin_transmission(self, I2C_WRITE);
     servo_driver_write_register(self, PCA9685_MODE1, self -> mode1 | 0xa1);
     // 0xa1 ensures the raising of the restart bit, ALLCALL, and auto-increment

--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -6,7 +6,10 @@ env = Environment(PIC='24FJ128GB206',
                   LINKFLAGS='-omf=elf -mcpu=$PIC -Wl,--script="app_p24FJ128GB206.gld"',
                   CPPPATH=['../lib'])
 env.PrependENVPath('PATH', '/opt/microchip/xc16/v1.25/bin')
-env.PrependENVPath('PATH', '/opt/microchip/xc16/v1.25/bin')
+env.PrependENVPath('PATH', '/opt/microchip/xc16/v1.25/support/generic/h')
+
+
+
 bin2hex = Builder(action='xc16-bin2hex $SOURCE -omf=elf',
                   suffix='hex',
                   src_suffix='elf')


### PR DESCRIPTION
Import common.h first so that FCY is defined. FCY is defined in common.h
